### PR TITLE
Prepare v0.5.6

### DIFF
--- a/CreateOrUpdateEnv.yml
+++ b/CreateOrUpdateEnv.yml
@@ -58,6 +58,9 @@
             aws s3api put-bucket-encryption \
               --bucket {{ project.name }}-cfn-templates \
               --server-side-encryption-configuration '{"Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]}'
+            aws s3api put-public-access-block \
+              --bucket {{ project.name }}-cfn-templates \
+              --public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
 
       tags: [ 'always' ]
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,13 @@
 * `p` release: Bugfixes, introduction of new features that can normally
   be used without any interruption or rebuild of resources.
 
+## `0.5.6`
+
+* Block all public access on bucket where template is uploaded
+* Remove start/stop metric filter and cw alarm from ecs service cloudwatch loggroups
+* Allow cross account ECR push for selected accounts
+
+
 ## `0.5.5` (20200926)
 
 A new module SGRules to add ingress rule to existing security groups.

--- a/templates/ECR.yml
+++ b/templates/ECR.yml
@@ -17,19 +17,45 @@ Resources:
       RepositoryPolicyText:
         Version: "2012-10-17"
         Statement:
+{%     if repo.cross_account_access.pull is defined %}
           -
             Sid: AllowPull
             Effect: Allow
             Principal:
               AWS:
-{%     for account_id in repo.cross_account_access.pull %}
+{%       for account_id in repo.cross_account_access.pull %}
                 - "arn:aws:iam::{{ account_id }}:root"
-{%     endfor %}
+{%       endfor %}
             Action:
               - "ecr:GetDownloadUrlForLayer"
               - "ecr:BatchGetImage"
               - "ecr:BatchCheckLayerAvailability"
               - "ecr:GetAuthorizationToken"
+{%     endif %}
+{%     if repo.cross_account_access.push is defined %}
+          -
+            Sid: AllowPush
+            Effect: Allow
+            Principal:
+              AWS:
+{%       for account_id in repo.cross_account_access.push %}
+                - "arn:aws:iam::{{ account_id }}:root"
+{%       endfor %}
+            Action:
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:BatchGetImage"
+              - "ecr:BatchCheckLayerAvailability"
+              - "ecr:GetAuthorizationToken"
+              - "ecr:GetRepositoryPolicy"
+              - "ecr:DescribeRepositories"
+              - "ecr:ListImages"
+              - "ecr:DescribeImages"
+              - "ecr:InitiateLayerUpload"
+              - "ecr:UploadLayerPart"
+              - "ecr:CompleteLayerUpload"
+              - "ecr:PutImage"
+
+{%     endif %}
 {%   endif %}
       LifecyclePolicy:
         LifecyclePolicyText: |

--- a/templates/ECS.yml
+++ b/templates/ECS.yml
@@ -413,17 +413,6 @@ Resources:
       LogGroupName: !Sub "cw-{{ project }}-{{ app.name }}"
       RetentionInDays: 14
 
-  ### AWS::CloudWatch::MetricFilter for CloudWatch logs for application {{ app.name }}
-  MetricFilterAppStart{{ cfn_project }}{{ app.cfn_name }}:
-    Type: "AWS::Logs::MetricFilter"
-    Properties:
-      LogGroupName: !Ref CloudWatch{{ cfn_project }}{{ app.cfn_name }}
-      FilterPattern: "{{ (app.monitoring | default({})).start_filter_string | default('Started Application in') }}"
-      MetricTransformations:
-        - MetricValue: "1"
-          MetricNamespace: "{{ cfn_project }}/ServiceStart"
-          MetricName: "{{ app.cfn_name }}"
-
 {%     if app.logs_subscription_filter is defined %}
   CWSubscrFilter{{ cfn_project }}{{ app.cfn_name }}:
     Type: AWS::Logs::SubscriptionFilter
@@ -433,25 +422,6 @@ Resources:
 {%     endif %}
       FilterPattern: '{{ app.logs_subscription_filter.filter_pattern | default('') }}'
       LogGroupName: !Ref CloudWatch{{ cfn_project }}{{ app.cfn_name }}
-{%     endif %}
-
-{%     if app.disable_alarm is not defined or app.disable_alarm %}
-  ### AWS::CloudWatch::Alarm for MetricFilterAppStart
-  AlarmAppStart{{ cfn_project }}{{ app.cfn_name }}:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      ActionsEnabled: "{{ (app.monitoring | default({})).alarm_actions_enabled | default('false') }}"
-      AlarmDescription: "Start Alarm for {{ cfn_project }}{{ app.cfn_name }}"
-      AlarmActions:
-        - !ImportValue "{{ organization.cfn_name | title }}MonitoringSubaccount-MonitoringSNSTopic"
-      MetricName: "{{ app.cfn_name }}"
-      Namespace: "{{ cfn_project }}/ServiceStart"
-      Statistic: Average
-      Period: '60'
-      EvaluationPeriods: '1'
-      Threshold: '1'
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
 {%     endif %}
 
   ### AWS::ECS::TaskDefinition for {{ app.name }}

--- a/templates/ECS2.yml
+++ b/templates/ECS2.yml
@@ -321,17 +321,6 @@ Resources:
       LogGroupName: !Sub "cw-{{ project }}-{{ app.name }}"
       RetentionInDays: 14
 
-  ### AWS::CloudWatch::MetricFilter for CloudWatch logs for application {{ app.name }}
-  MetricFilterAppStart{{ app.cfn_name }}:
-    Type: "AWS::Logs::MetricFilter"
-    Properties:
-      LogGroupName: !Ref CW{{ app.cfn_name }}
-      FilterPattern: "{{ (app.monitoring | default({})).start_filter_string | default('Started Application in') }}"
-      MetricTransformations:
-        - MetricValue: "1"
-          MetricNamespace: "{{ cfn_project }}/ServiceStart"
-          MetricName: "{{ app.cfn_name }}"
-
 {%     if app.logs_subscription_filter is defined %}
   CWSubscrFilter{{ app.cfn_name }}:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
* Block all public access on bucket where template is uploaded
* Remove start/stop metric filter and cw alarm from ecs service cloudwatch loggroups
* allow cross account ECR push for selected accounts