### PR TITLE
Release v0.6.0

### DIFF
--- a/CreateOrUpdateEnv.yml
+++ b/CreateOrUpdateEnv.yml
@@ -780,12 +780,6 @@
 
     - name: Lambda
       block:
-        - name: Get unique version_id to name the Lambda version resource
-          shell: openssl rand -hex 12
-          register: openssl
-        - name: Save version_id
-          set_fact:
-            version_id: "{{ openssl.stdout }}"
         - name: Create CFN template from Ansible template for the Lambda functions
           template:
             src: "Lambda.yml"
@@ -828,12 +822,6 @@
 
     - name: LambdaCloudfront
       block:
-        - name: Get unique version_id to name the Lambda version resource
-          shell: openssl rand -hex 12
-          register: openssl
-        - name: Save version_id
-          set_fact:
-            version_id: "{{ openssl.stdout }}"
         - name: Create CFN template from Ansible template for the Lambda functions in us-east-1
           template:
             src: "LambdaCloudfront.yml"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,19 @@
 * `p` release: Bugfixes, introduction of new features that can normally
   be used without any interruption or rebuild of resources.
 
+## `0.6.0` (20201124)
+
+### Warning
+
+Upgrading to this version will possibly cause downtime because new AMI's will be used
+
+### Changes
+ 
+* Default TLS policies for ALB and CloudFront are updated to `ELBSecurityPolicy-FS-1-2-Res-2019-08`
+  and `TLSv1.2_2019` respectively
+* AMI's for Bastion and ECS cluster are updated
+* Only Amazon2 linux AMI's are allowed for EC2 based ECS clusters and Bastion hosts
+
 ## `0.5.12` (20201118)
 
 Bugfixes in CloudFormation lint checker

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,10 @@
 * `p` release: Bugfixes, introduction of new features that can normally
   be used without any interruption or rebuild of resources.
 
+## `0.5.11` (20201118)
+
+Bugfixes in CloudFormation lint checker
+
 ## `0.5.10` (20201117)
 
 Add `cfn-lint` check after template generation, but before template deploy

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,10 @@
 * `p` release: Bugfixes, introduction of new features that can normally
   be used without any interruption or rebuild of resources.
 
+## `0.5.12` (20201118)
+
+Bugfixes in CloudFormation lint checker
+
 ## `0.5.11` (20201118)
 
 Bugfixes in CloudFormation lint checker

--- a/templates/BastionHost.yml
+++ b/templates/BastionHost.yml
@@ -7,13 +7,13 @@ Description: |
 Mappings:
   AWSRegionToAmzn2AMI:
     eu-central-1:
-      AMIID: ami-0cc293023f983ed53
+      AMIID: ami-0649a2ac1437cf3b7
     eu-west-1:
-      AMIID: ami-0bbc25e23a7640b9b
+      AMIID: ami-014ce76919b528bff
     eu-west-2:
-      AMIID: ami-0d8e27447ec2c8410
+      AMIID: ami-0271d331ac7dab654
     eu-west-3:
-      AMIID: ami-0adcddd3324248c4c
+      AMIID: ami-0c3d23d707737957d
 
 Resources:
 

--- a/templates/ECS.yml
+++ b/templates/ECS.yml
@@ -143,28 +143,28 @@ Resources:
   ContainerInstances:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
-{%   if ecs.cluster.amz2ami is defined %}
+{% if ecs.cluster.amz2ami is defined %}
       ImageId: {{ ecs.cluster.amz2ami }}
-{%   else %}
+{% else %}
       ImageId: !FindInMap [AWSRegionToAmzn2AMI, !Ref 'AWS::Region', AMIID]
-{%   endif %}
+{% endif %}
       SecurityGroups:
         - "{{ vpc_sg_app }}"
       InstanceType: "{{ ecs.cluster.instance_type }}"
       IamInstanceProfile: !Ref 'EC2InstanceProfile'
-{%   if (ecs.cluster.ebs_size is defined) or (ecs.cluster.encrypt_ebs | default(false)) %}
+{% if (ecs.cluster.ebs_size is defined) or (ecs.cluster.encrypt_ebs | default(false)) %}
       BlockDeviceMappings:
         - DeviceName: "/dev/xvda"
           Ebs:
             VolumeSize: "{{ ecs.cluster.ebs_size | default('30') }}"
-{%     if ecs.cluster.encrypt_ebs | default(false) %}
+{%   if ecs.cluster.encrypt_ebs | default(false) %}
             Encrypted: true
-{%     endif %}
 {%   endif %}
+{% endif %}
       KeyName: "{{ ecs.cluster.keypair }}"
-{%   if ecs.cluster.spot_price is defined %}
+{% if ecs.cluster.spot_price is defined %}
       SpotPrice: "{{ ecs.cluster.spot_price }}"
-{%   endif %}
+{% endif %}
       UserData:
         Fn::Base64:
           Fn::Sub:
@@ -186,14 +186,14 @@ Resources:
             yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm || true
             cd -
 
-{%   if ecs.efs is defined %}
+{% if ecs.efs is defined %}
             yum install -y nfs-utils
-{%     for fs in ecs.efs | default([]) %}
+{%   for fs in ecs.efs | default([]) %}
             mkdir -p {{ fs.mountpoint }}
             echo -e '{{ '${' }}{{ fs.export_name }}{{ '}' }}.efs.${AWS::Region}.amazonaws.com:/ {{ fs.mountpoint }} nfs4 noresvport,_netdev,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0' >> /etc/fstab
             mount -a
-{%     endfor %}
-{%   endif %}
+{%   endfor %}
+{% endif %}
             echo ECS_CLUSTER=${ECSCluster} >> /etc/ecs/ecs.config
             yum install -y https://s3.amazonaws.com/amazoncloudwatch-agent/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm || true
             yum install -y aws-cfn-bootstrap hibagent
@@ -204,11 +204,11 @@ Resources:
           -
             dummy:
               "dummy"
-{%   for fs in ecs.efs | default([]) %}
+{% for fs in ecs.efs | default([]) %}
             {{ fs.export_name }}:
               Fn::ImportValue:
                 "{{ fs.export_name }}"
-{%   endfor %}
+{% endfor %}
     Metadata:
       AWS::CloudFormation::Init:
         config:
@@ -223,12 +223,12 @@ Resources:
               command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c ssm:AmazonCloudWatch-linux -s
             03_create_authorized_keys_file:
               command: /usr/local/bin/create_authorized_keys
-{%   if ecs.metadata is defined and ecs.metadata.commands is defined %}
-{%     for metadata_command in ecs.metadata.commands %}
+{% if ecs.metadata is defined and ecs.metadata.commands is defined %}
+{%   for metadata_command in ecs.metadata.commands %}
             {{ metadata_command.id}}:
               command: {{ metadata_command.command }}
-{%     endfor %}
-{%   endif %}
+{%   endfor %}
+{% endif %}
           files:
             /usr/local/bin/create_authorized_keys:
               mode: "000755"
@@ -237,11 +237,11 @@ Resources:
               content: |
                 #! /bin/env bash
                 echo "### Updating /home/ec2-user/.ssh/authorized_keys ###"
-{%   if bastion is defined and bastion.pubkeys is defined %}
-{%     for key in bastion.pubkeys %}
+{% if bastion is defined and bastion.pubkeys is defined %}
+{%   for key in bastion.pubkeys %}
                 grep -q '{{ key.key }}' /home/ec2-user/.ssh/authorized_keys || echo '{{ key.key }}' >> /home/ec2-user/.ssh/authorized_keys
-{%     endfor %}
-{%   endif %}
+{%   endfor %}
+{% endif %}
             /etc/cfn/cfn-hup.conf:
               mode: "000400"
               owner: root

--- a/templates/ECS.yml
+++ b/templates/ECS.yml
@@ -12,15 +12,6 @@ Description: |
 
 ### For latest ECS optimized AMIs: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
 Mappings:
-  AWSRegionToAMI:
-    eu-central-1:
-      AMIID: ami-0c92441731cf7df4a
-    eu-west-1:
-      AMIID: ami-0d346d805b551eb23
-    eu-west-2:
-      AMIID: ami-047dc5a6f3b76d064
-    eu-west-3:
-      AMIID: ami-033fd8e7b5595cf76
   AWSRegionToAmzn2AMI:
     eu-central-1:
       AMIID: ami-0e6de310858faf4dc
@@ -149,7 +140,6 @@ Resources:
           Id: "TargetMonitoringSNSTopic"
 
 
-{% if ecs.cluster.amzn2 is defined and ecs.cluster.amzn2 %}
   ContainerInstances:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
@@ -275,100 +265,6 @@ Resources:
                 files:
                   - /etc/cfn/cfn-hup.conf
                   - /etc/cfn/hooks.d/cfn-auto-reloader.conf
-{% else %}
-{# LaunchConfiguration for Amazon Linux 1 clusters #}
-  ContainerInstances:
-    Type: AWS::AutoScaling::LaunchConfiguration
-    Properties:
-{%   if ecs.cluster.amzami is defined %}
-      ImageId: {{ ecs.cluster.amzami }}
-{%   else %}
-      ImageId: !FindInMap [AWSRegionToAMI, !Ref 'AWS::Region', AMIID]
-{%   endif %}
-      SecurityGroups:
-        - "{{ vpc_sg_app }}"
-      InstanceType: "{{ ecs.cluster.instance_type }}"
-      IamInstanceProfile: !Ref 'EC2InstanceProfile'
-{%   if (ecs.cluster.ebs_size is defined) or (ecs.cluster.encrypt_ebs | default(false)) %}
-      BlockDeviceMappings:
-      - DeviceName: "/dev/xvdcz"
-        Ebs:
-          VolumeSize: "{{ ecs.cluster.ebs_size | default('30') }}"
-{%     if ecs.cluster.encrpyt_ebs | default(false) %}
-          Encrypted: true
-{%     endif %}
-{%   endif %}
-      KeyName: "{{ ecs.cluster.keypair }}"
-{%   if ecs.cluster.spot_price is defined %}
-      SpotPrice: "{{ ecs.cluster.spot_price }}"
-{%   endif %}
-      UserData:
-        Fn::Base64:
-          Fn::Sub:
-          - |
-            Content-Type: multipart/mixed; boundary="===============8943416319660996992=="
-            MIME-Version: 1.0
-
-{%   if ecs.cluster.dm_basesize is defined %}
-            --===============8943416319660996992==
-            Content-Type: text/cloud-boothook; charset="us-ascii"
-            MIME-Version: 1.0
-            Content-Transfer-Encoding: 7bit
-            Content-Disposition: attachment; filename="docker_options.cloudinit"
-
-            #cloud-boothook
-              cloud-init-per once docker_options echo 'OPTIONS="$OPTIONS --storage-opt dm.basesize={{ ecs.cluster.dm_basesize }}"' >> /etc/sysconfig/docker
-
-{%   endif %}
-            --===============8943416319660996992==
-            Content-Type: text/x-shellscript; charset="us-ascii"
-            MIME-Version: 1.0
-            Content-Transfer-Encoding: 7bit
-            Content-Disposition: attachment; filename="ecs_config.cloudinit"
-
-            #!/bin/bash -xe
-
-            ### Install SSM agent
-            cd /tmp
-            yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm || true
-            start amazon-ssm-agent || true
-            cd -
-
-{%   if ecs.efs is defined %}
-            yum install -y nfs-utils
-{%     for fs in ecs.efs | default([]) %}
-            mkdir -p {{ fs.mountpoint }}
-            echo -e '{{ '${' }}{{ fs.export_name }}{{ '}' }}.efs.${AWS::Region}.amazonaws.com:/ {{ fs.mountpoint }} nfs4 noresvport,_netdev,nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 0 0' >> /etc/fstab
-            mount -a
-{%     endfor %}
-{%   endif %}
-            echo ECS_CLUSTER=${ECSCluster} >> /etc/ecs/ecs.config
-            yum install -y aws-cfn-bootstrap
-            /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackName} --resource ECSAutoScalingGroup --region ${AWS::Region}
-
-{%   if bastion is defined and bastion.pubkeys is defined %}
-            --===============8943416319660996992==
-            Content-Type: text/cloud-config; charset="us-ascii"
-            MIME-Version: 1.0
-            Content-Transfer-Encoding: 7bit
-            Content-Disposition: attachment; filename="ec2_user_pubkeys.cloudinit"
-
-            #cloud-config
-            runcmd:
-{%     for key in bastion.pubkeys %}
-            - echo '{{ key.key }}' >> /home/ec2-user/.ssh/authorized_keys
-{%     endfor %}
-
-{%   endif %}
-          -
-            dummy:
-              "dummy"
-{%   for fs in ecs.efs | default([]) %}
-            {{ fs.export_name }}:
-              Fn::ImportValue:
-                "{{ fs.export_name }}"
-{%   endfor %}
-{% endif %}
 
 {% if non_fargate_count.value > 0 %}
   ECSAutoScalingGroup:

--- a/templates/ECS.yml
+++ b/templates/ECS.yml
@@ -14,22 +14,22 @@ Description: |
 Mappings:
   AWSRegionToAMI:
     eu-central-1:
-      AMIID: ami-091ae1d0073cfc44e
+      AMIID: ami-0c92441731cf7df4a
     eu-west-1:
-      AMIID: ami-0d3c55e1582bd84fd
+      AMIID: ami-0d346d805b551eb23
     eu-west-2:
-      AMIID: ami-033427751d2bcb33a
+      AMIID: ami-047dc5a6f3b76d064
     eu-west-3:
-      AMIID: ami-0288926e74a35212f
+      AMIID: ami-033fd8e7b5595cf76
   AWSRegionToAmzn2AMI:
     eu-central-1:
-      AMIID: ami-065c1e34da68f2b02
+      AMIID: ami-0e6de310858faf4dc
     eu-west-1:
-      AMIID: ami-0c9ef930279337028
+      AMIID: ami-0bf2c3827d202c3bb
     eu-west-2:
-      AMIID: ami-0ce75da72db51b0f0
+      AMIID: ami-08265e8ea5c79d579
     eu-west-3:
-      AMIID: ami-015011bcdf1c3377a
+      AMIID: ami-0c566b8d4c555b53e
 
 Resources:
 

--- a/templates/ECS2.yml
+++ b/templates/ECS2.yml
@@ -14,13 +14,13 @@ Description: |
 Mappings:
   AWSRegionToAmzn2AMI:
     eu-central-1:
-      AMIID: ami-065c1e34da68f2b02
+      AMIID: ami-0e6de310858faf4dc
     eu-west-1:
-      AMIID: ami-0c9ef930279337028
+      AMIID: ami-0bf2c3827d202c3bb
     eu-west-2:
-      AMIID: ami-0ce75da72db51b0f0
+      AMIID: ami-08265e8ea5c79d579
     eu-west-3:
-      AMIID: ami-015011bcdf1c3377a
+      AMIID: ami-0c566b8d4c555b53e
   Region2ELBAccountId:
     us-east-1:
       AccountId: "127311923021"

--- a/templates/Lambda.yml
+++ b/templates/Lambda.yml
@@ -75,13 +75,6 @@ Resources:
         - Key: Customer
           Value: "{{ customer | default('NA') }}"
 
-# TODO: Version creation fails when function is unchanged
-#  {{ lambda_cfn_name }}Version{{ version_id }}:
-#    Type: AWS::Lambda::Version
-#    Properties:
-#      FunctionName: !Ref {{ lambda_cfn_name }}
-
-
 {%   for liv in lambda.invoke_permissions | default([]) %}
 {%     if liv.type == 'predefined' and liv.name == 'logs' %}
   {{ lambda_cfn_name }}InvokePermission:
@@ -158,13 +151,5 @@ Outputs:
     Description: "Lambda function {{ lambda_cfn_name }} Arn"
     Export:
       Name: !Sub "${AWS::StackName}-{{ lambda_cfn_name }}Arn"
-
-# TODO: Version creation fails when function is unchanged
-#  {{ lambda_cfn_name }}VersionOutput:
-#    Value: !GetAtt {{ lambda_cfn_name }}Version{{ version_id }}.Version
-#    Description: "Lambda Version {{ lambda_cfn_name }}Version{{ version_id }} Version"
-#    Export:
-#      Name: !Sub "${AWS::StackName}-{{ lambda_cfn_name }}VersionVersion"
-
 
 {% endfor %}

--- a/templates/LambdaCloudfront.yml
+++ b/templates/LambdaCloudfront.yml
@@ -56,13 +56,6 @@ Resources:
         - Key: Customer
           Value: "{{ customer | default('NA') }}"
 
-# TODO: Version creation fails when function is unchanged
-#  {{ lambda_cfn_name }}Version{{ version_id }}:
-#    Type: AWS::Lambda::Version
-#    Properties:
-#      FunctionName: !Ref {{ lambda_cfn_name }}
-
-
 {%   for liv in lambda.invoke_permissions | default([]) %}
 {%     if liv.type == 'predefined' and liv.name == 'logs' %}
   {{ lambda_cfn_name }}CWLogsInvokePermission:
@@ -104,13 +97,5 @@ Outputs:
     Description: "Lambda function {{ lambda_cfn_name }} Arn"
     Export:
       Name: !Sub "${AWS::StackName}-{{ lambda_cfn_name }}Arn"
-
-# TODO: Version creation fails when function is unchanged
-#  {{ lambda_cfn_name }}VersionOutput:
-#    Value: !GetAtt {{ lambda_cfn_name }}Version{{ version_id }}.Version
-#    Description: "Lambda Version {{ lambda_cfn_name }}Version{{ version_id }} Version"
-#    Export:
-#      Name: !Sub "${AWS::StackName}-{{ lambda_cfn_name }}VersionVersion"
-
 
 {% endfor %}


### PR DESCRIPTION
* Default TLS policies for ALB and CloudFront are updated to `ELBSecurityPolicy-FS-1-2-Res-2019-08`
  and `TLSv1.2_2019` respectively
* AMI's for Bastion and ECS cluster are updated
* Only Amazon2 linux AMI's are allowed for EC2 based ECS clusters and Bastion hosts
