### PR TITLE
Release v0.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ to deploy these AWS CloudFormation templates to the desired account.
 
 The _Docker_ image contains a combination of _ansible_ and _AWS CLI_ versions, and running
 the _Docker_ image with the right set of environment variables allows the user to choose
-the _tag_ in this repository to checkout for the build and deploy.
+the _tag_ in this repository to check out for the build and deploy.
 
 The _Docker_ image is called `ixor/ansible-aws-cfn-gen` and can be
 found [here](https://hub.docker.com/r/ixor/ansible-aws-cfn-gen/). The documentation for
@@ -725,6 +725,9 @@ loadbalancers:
   - name: ALBExt
     scheme: "internet-facing"
     certificate_arn: "arn:aws:acm:eu-central-1:123456789012:certificate/55555555-4444-4444-7777-555555555555"
+    listener_certificate_list:
+      - cfn_name: "Cert2"
+        arn: "arn:aws:acm:eu-central-1:123456789012:certificate/88888888-2222-6666-9999-111111111111"
     def_tg_http_healthcheckpath: /health
     def_tg_https_healthcheckpath: /health
   - name: ALBInt
@@ -742,10 +745,23 @@ loadbalancers:
         filter_pattern: "-DEBUG"  
 ```
 
-#### `ssl_policy` (optional, default is `ELBSecurityPolicy-2016-08`)
+#### `certificate_arn`: The default certificate to use
 
-The SSL/TLS policy to use for the HTTPS listener. It defaults to today's AWS default
-`ELBSecurityPolicy-2016-08`, and can have any value from the list you can find
+#### `listener_certificate_list`: Optional certificates to add to the listener
+
+Each element in the list has 2 properties:
+
+* `cfn_name`: An alphanumerical string used to uniquely name the CloudFormation resource
+* `arn`: The ARN of an existing and validated Certificate in the same account and region as
+  the load blancer is is user for
+
+For more information on the subject, also see
+[here](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#sni-certificate-list)
+
+#### `ssl_policy` (optional, default is `ELBSecurityPolicy-FS-1-2-Res-2019-08`)
+
+The SSL/TLS policy to use for the HTTPS listener. It defaults to
+`ELBSecurityPolicy-FS-1-2-Res-2019-08`, and can have any value from the list you can find
 [here](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies).
 
 #### `access_logs`

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Following _modules_ have their own documentation file:
 * [Elastic Container Registry](docs/ECR.md)
 * [Elastic Container Service](docs/ECS.md)
 * [The mamagement ECS Fargate cluster](docs/ECSMgmt.md)
-* [KMS](docs/MKS.md)
+* [KMS](docs/KMS.md)
 * [RDS](docs/RDS.md)
 * [RDS Parameter Group](docs/RDSParameterGroups.md)
 * [SecretsManager](docs/SecretsManager.md)
@@ -1103,6 +1103,10 @@ For each service, a lot of resources are created:
         priority: 211
         skiproute53: false
 ```
+
+The role `ECSExecutionRoleAwsCfnGen` that is implicitly created by the IAM
+module will be used as `ExecutionRoleArn` in the task definitions if no
+`execution_role_arn` is defined in the service configuration.
 
 #### `applicationconfig[n].name`
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,10 @@
 * `p` release: Bugfixes, introduction of new features that can normally
   be used without any interruption or rebuild of resources.
 
+## `0.6.5` (20201229)
+
+Allow multiple certificates on 1 ALB HTTPS listener (fixes #53)
+
 ## `0.6.3` (20201210) and `0.6.4` (20201212)
 
 AWS decided to stop support for their case error in `FileSystemId`, so we are

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,12 @@
 * `p` release: Bugfixes, introduction of new features that can normally
   be used without any interruption or rebuild of resources.
 
+## `0.6.6` (20210102)
+
+Implicitly create the role `ECSExecutionRoleAwsCfnGen` and use it as the
+`ExecutionRoleArn` in the task definitions if no `execution_role_arn` is defined
+in the service configuration.
+
 ## `0.6.5` (20201229)
 
 Allow multiple certificates on 1 ALB HTTPS listener (fixes #53)

--- a/templates/ALB.yml
+++ b/templates/ALB.yml
@@ -37,7 +37,6 @@ Mappings:
     eu-central-1:
       AccountId: "054676820928"
 
-
 Resources:
 
 {% if item.accesslogs is defined and item.accesslogs.state == 'enabled' %}
@@ -171,6 +170,16 @@ Resources:
       SslPolicy: "{{ item.ssl_policy | default('ELBSecurityPolicy-FS-1-2-Res-2019-08') }}"
       Certificates:
         - CertificateArn: {{ item.certificate_arn }}
+
+{%   for listener_certificate in item.listener_certificate_list | default([]) %}
+  Certificate{{ item.name }}{{ listener_certificate.cfn_name }}:
+    Type: AWS::ElasticLoadBalancingV2::ListenerCertificate
+    Properties:
+      Certificates:
+        - CertificateArn: {{ listener_certificate.arn }}
+      ListenerArn: !Ref Listener{{ item.name }}
+{%   endfor %}
+
   Listener{{ item.name }}HTTP:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:

--- a/templates/ECS.yml
+++ b/templates/ECS.yml
@@ -401,6 +401,8 @@ Resources:
 {%     endif %}
 {%     if app.ecs.execution_role_arn is defined %}
       ExecutionRoleArn: "{{ app.ecs.execution_role_arn }}"
+{%     else %}
+      ExecutionRoleArn: "arn:aws:iam::{{ target_account.account_id  }}:role/ECSExecutionRoleAwsCfnGen"
 {%     endif %}
 
 {%     if app.target | lower == 'ecs_scheduled_task' %}

--- a/templates/ECS2.yml
+++ b/templates/ECS2.yml
@@ -413,6 +413,8 @@ Resources:
 {%     endif %}
 {%     if app.ecs.execution_role_arn is defined %}
       ExecutionRoleArn: "{{ app.ecs.execution_role_arn }}"
+{%     else %}
+      ExecutionRoleArn: "arn:aws:iam::{{ target_account.account_id  }}:role/ECSExecutionRoleAwsCfnGen"
 {%     endif %}
 
 {%     if app.target | lower == 'ecs_scheduled_task' %}

--- a/templates/ECS2.yml
+++ b/templates/ECS2.yml
@@ -690,6 +690,16 @@ Resources:
       SslPolicy: "{{ item.ssl_policy | default('ELBSecurityPolicy-FS-1-2-Res-2019-08') }}"
       Certificates:
         - CertificateArn: {{ item.certificate_arn }}
+
+{%   for listener_certificate in item.listener_certificate_list | default([]) %}
+  Certificate{{ item.name }}{{ listener_certificate.cfn_name }}:
+    Type: AWS::ElasticLoadBalancingV2::ListenerCertificate
+      Properties:
+        Certificates:
+          - CertificateArn: {{ listener_certificate.arn }}
+        ListenerArn: !Ref Listener{{ item.name }}
+{%   endfor %}
+
   Listener{{ item.name }}HTTP:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:

--- a/templates/IAM.yml
+++ b/templates/IAM.yml
@@ -4,6 +4,15 @@ Description: |
 
 Resources:
 
+  ECSExecutionRoleAwsCfnGen:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: ECSExecutionRole
+      AssumeRolePolicyDocument:
+        {"Version": "2012-10-17", "Statement": [{"Sid": "", "Effect": "Allow", "Principal": {"Service": "ecs-tasks.amazonaws.com"}, "Action": "sts:AssumeRole"}]}
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
 {% if managed_policies is defined %}
 {%   for policy in managed_policies | default([]) %}
   {{ policy.name }}Policy:


### PR DESCRIPTION
Implicitly create the role `ECSExecutionRoleAwsCfnGen` and use it as the
`ExecutionRoleArn` in the task definitions if no `execution_role_arn` is defined
in the service configuration.