### PR TITLE
Fix indentation error in ECS2 module

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,10 @@
 Adding ACM certificates to a ALB in ECS2 failed because of an indentation error. This
 version fixes that error.
 
+### BastionHost: Update AMI
+
+The AMI used for the bastion host is updated to the latest version.
+
 ## `0.6.13` (20210604)
 
 ### EFS: S3 to EFS copy

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,13 @@
 * `p` release: Bugfixes, introduction of new features that can normally
   be used without any interruption or rebuild of resources.
 
+## `0.6.14` (20210617)
+
+### ECS2: Fix indentation error
+
+Adding ACM certificates to a ALB in ECS2 failed because of an indentation error. This
+versino fixes that error.
+
 ## `0.6.13` (20210604)
 
 ### EFS: S3 to EFS copy

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,7 +14,7 @@
 ### ECS2: Fix indentation error
 
 Adding ACM certificates to a ALB in ECS2 failed because of an indentation error. This
-versino fixes that error.
+version fixes that error.
 
 ## `0.6.13` (20210604)
 

--- a/templates/BastionHost.yml
+++ b/templates/BastionHost.yml
@@ -7,13 +7,13 @@ Description: |
 Mappings:
   AWSRegionToAmzn2AMI:
     eu-central-1:
-      AMIID: "ami-0a6dc7529cd559185"
+      AMIID: "ami-043097594a7df80ec"
     eu-west-1:
-      AMIID: "ami-0fc970315c2d38f01"
+      AMIID: "ami-063d4ab14480ac177"
     eu-west-2:
-      AMIID: "ami-098828924dc89ea4a"
+      AMIID: "ami-06dc09bb8854cbde3"
     eu-west-3:
-      AMIID: "ami-0ea4a063871686f37"
+      AMIID: "ami-0b3e57ee3b63dd76b"
 
 Resources:
 

--- a/templates/ECS2.yml
+++ b/templates/ECS2.yml
@@ -736,10 +736,10 @@ Resources:
 {%   for listener_certificate in item.listener_certificate_list | default([]) %}
   Certificate{{ item.name }}{{ listener_certificate.cfn_name }}:
     Type: AWS::ElasticLoadBalancingV2::ListenerCertificate
-      Properties:
-        Certificates:
-          - CertificateArn: {{ listener_certificate.arn }}
-        ListenerArn: !Ref Listener{{ item.name }}
+    Properties:
+      Certificates:
+        - CertificateArn: {{ listener_certificate.arn }}
+      ListenerArn: !Ref Listener{{ item.name }}
 {%   endfor %}
 
   Listener{{ item.name }}HTTP:


### PR DESCRIPTION
* Adding ACM certificates to a ALB in ECS2 failed because of an indentation error. This version fixes that error.
* The AMI for bastion host is updated to the latest version