### PR TITLE
Improvements for Lambda@Edge

### DIFF
--- a/CreateOrUpdateEnv.yml
+++ b/CreateOrUpdateEnv.yml
@@ -49,11 +49,23 @@
         - name: Disable all alarms during playbook execution
           shell: |
             aws cloudwatch disable-alarm-actions --alarm-names $(aws cloudwatch describe-alarms --query "MetricAlarms[*].AlarmName" --output text)
-        - name: Create S3 bucket to hold CloudFormation templates
+        - name: "Create S3 bucket to hold CloudFormation templates"
           shell: |
             if ! aws s3 ls | grep "{{ project.name }}-cfn-templates"
             then
               aws s3 mb "s3://{{ project.name }}-cfn-templates"
+            fi
+            aws s3api put-bucket-encryption \
+              --bucket {{ project.name }}-cfn-templates \
+              --server-side-encryption-configuration '{"Rules": [{"ApplyServerSideEncryptionByDefault": {"SSEAlgorithm": "AES256"}}]}'
+            aws s3api put-public-access-block \
+              --bucket {{ project.name }}-cfn-templates \
+              --public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+        - name: "Create S3 bucket to hold CloudFormation templates in us-east-1"
+          shell: |
+            if ! aws s3 ls | grep "{{ project.name }}-cfn-templates-us-east-1" --region us-east-1
+            then
+              aws s3 mb "s3://{{ project.name }}-cfn-templates-us-east-1" --region us-east-1
             fi
             aws s3api put-bucket-encryption \
               --bucket {{ project.name }}-cfn-templates \
@@ -894,16 +906,17 @@
         - name: Put CFN template on s3
           shell: |
             aws s3 cp "{{ generated_files_dir | default('generated-files') }}/cfn-{{ project }}-lambdacloudfront.yml" \
-                      "s3://{{ project }}-cfn-templates/cfn-{{ project }}-lambdacloudfront.yml"
+                      "s3://{{ project }}-cfn-templates-us-east-1/cfn-{{ project }}-lambdacloudfront.yml"
           tags: [ 'deploy' ]
         - name: Get presigned URL for the template on S3
           shell: |
-            aws s3 presign "s3://{{ project }}-cfn-templates/cfn-{{ project }}-lambdacloudfront.yml"
+            aws s3 presign "s3://{{ project }}-cfn-templates-us-east-1/cfn-{{ project }}-lambdacloudfront.yml"
           register: presign
           tags: [ 'deploy' ]
         - name: Create or Update the Lambda CloudFormation stack
           cloudformation:
             region: us-east-1
+            capabilities: ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM", "CAPABILITY_AUTO_EXPAND"]
             stack_name: "{{ cfn_project }}LambdaCloudfront"
             create_changeset: "{{ create_changeset }}"
             changeset_name: "{{ cfn_project }}LambdaCloudfront{{ changeset_suffix }}"
@@ -922,7 +935,7 @@
                 --output text >> changeset_report.txt
           when: "create_changeset is defined and create_changeset == 'yes'"
           tags: [ 'deploy' ]
-      when: "lambda_functions_cloudfront is defined"
+      when: "lambda_functions_cloudfront is defined or lambda_functions_cloudfront_v2 is defined"
       tags: [ 'lambdacloudfront' ]
 
     - name: CloudWatch

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,10 @@
 * `p` release: Bugfixes, introduction of new features that can normally
   be used without any interruption or rebuild of resources.
 
+## `0.6.16` (20210715)
+
+### LambdaCloudfront: use AWS::Serverless::Function to created versioned functions in us-east-1
+
 ## `0.6.15` (20210715)
 
 ### CloudFront: Re-use a s3 origin for multiple distributions

--- a/templates/LambdaCloudfront.yml
+++ b/templates/LambdaCloudfront.yml
@@ -1,5 +1,7 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
 Description: |
   Create Lambda functions in us-east-1 for use by CloudFront Lambda@Edge (aws-cfn-gen version: {{ gittag | default('na') }})
 
@@ -11,7 +13,6 @@ Resources:
 {#   Create some variables #}
 {%   set lambda_cfn_name = lambda.name | replace('-', ' ') | replace('_', ' ') | replace('.', ' ') | title | replace(' ', '') %}
 {%   set lambda_fn_name = (lambda.name.split('_'))[0] %}
-
 
   {{ lambda_cfn_name }}:
     Type: AWS::Lambda::Function
@@ -26,28 +27,10 @@ Resources:
 {% else %}
       Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/{{ lambda.role }}"
 {% endif %}
-{%   if lambda.environment is defined %}
-      Environment:
-        Variables:
-{%     for env in lambda.environment %}
-         {{ env.name }}: "{{ env.value }}"
-{%     endfor %}
-{%   endif %}
       Code:
         S3Bucket: "{{ lambda.code.s3_bucket }}"
         S3Key: "{{ lambda.code.s3_key }}"
       Runtime: {{ lambda.runtime | default('python2.7') }}
-{%   if lambda.vpc is defined and lambda.vpc %}
-      VpcConfig:
-        SubnetIds:
-          - "{{ vpc_privatesubnet_az1 }}"
-          - "{{ vpc_privatesubnet_az2 }}"
-{%     if vpc_nr_of_azs == 3 %}
-          - "{{ vpc_privatesubnet_az3 }}"
-{%     endif %}
-        SecurityGroupIds:
-          - "{{ vpc_sg_app }}"
-{%   endif %}
       Tags:
         - Key: Application
           Value: "{{ application }}"
@@ -55,34 +38,28 @@ Resources:
           Value: "{{ env }}"
         - Key: Customer
           Value: "{{ customer | default('NA') }}"
+{% endfor %}
 
-{%   for liv in lambda.invoke_permissions | default([]) %}
-{%     if liv.type == 'predefined' and liv.name == 'logs' %}
-  {{ lambda_cfn_name }}CWLogsInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !Ref {{ lambda_cfn_name }}
-      Principal: !Sub "logs.${AWS::Region}.amazonaws.com"
-      SourceAccount: !Ref AWS::AccountId
-{%     endif %}
+{# Create Lambda@Edge functions (v2)) #}
+{% for lambda_edge in lambda_functions_cloudfront_v2 | default([]) %}
+{#   Create some variables #}
+{%   set lambda_cfn_name = lambda_edge.name | replace('-', ' ') | replace('_', ' ') | replace('.', ' ') | title | replace(' ', '') %}
+  {{ lambda_cfn_name }}:
+      Type: AWS::Serverless::Function
+      Properties:
+        FunctionName: "{{ lambda_edge.name}}"
+        CodeUri: "{{ lambda_edge.code_uri }}"
+        Role: "{{ lambda_edge.role_arn }}"
+        Runtime: "{{ lambda_edge.runtime }}"
+        Handler: "{{ lambda_edge.handler }}"
+        Timeout: {{ lambda_edge.timeout | default(3) }}
+        MemorySize: {{ lambda_edge.memory_size | default(128) }}
+        AutoPublishAlias: live
 
-{%     if liv.type == 'predefined' and liv.name == 's3' %}
-  {{ lambda_cfn_name }}CWLogsInvokePermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !Ref {{ lambda_cfn_name }}
-      Principal: "s3.amazonaws.com"
-      SourceAccount: !Ref AWS::AccountId
-      SourceArn: "{{ liv.bucket_arn }}"
-{%     endif %}
-
-{%   endfor %}
 {% endfor %}
 
 Outputs:
-{% for lambda in lambda_functions_cloudfront %}
+{% for lambda in lambda_functions_cloudfront | default([]) %}
 {#   Create some variables #}
 {%   set lambda_cfn_name = lambda.name | replace('-', ' ') | replace('_', ' ') | replace('.', ' ') | title | replace(' ', '') %}
 
@@ -97,5 +74,28 @@ Outputs:
     Description: "Lambda function {{ lambda_cfn_name }} Arn"
     Export:
       Name: !Sub "${AWS::StackName}-{{ lambda_cfn_name }}Arn"
+
+{% endfor %}
+{% for lambda in lambda_functions_cloudfront_v2 | default([]) %}
+{#   Create some variables #}
+{%   set lambda_cfn_name = lambda.name | replace('-', ' ') | replace('_', ' ') | replace('.', ' ') | title | replace(' ', '') %}
+
+  {{ lambda_cfn_name }}Output:
+    Value: !Ref {{ lambda_cfn_name }}
+    Description: "Lambda function {{ lambda_cfn_name }} resource logical name"
+    Export:
+      Name: !Sub "${AWS::StackName}-{{ lambda_cfn_name }}"
+
+  {{ lambda_cfn_name }}ArnOutput:
+    Value: !GetAtt {{ lambda_cfn_name }}.Arn
+    Description: "Lambda function {{ lambda_cfn_name }} Arn"
+    Export:
+      Name: !Sub "${AWS::StackName}-{{ lambda_cfn_name }}Arn"
+
+  {{ lambda_cfn_name }}VersionArnOutput:
+    Value: !Ref {{ lambda_cfn_name }}.Version
+    Description: "Lambda function {{ lambda_cfn_name }} Version Arn"
+    Export:
+      Name: !Sub "${AWS::StackName}-{{ lambda_cfn_name }}VersionArn"
 
 {% endfor %}


### PR DESCRIPTION
* User `AWS::Serverless::Function` to create versioned Lambda functions in `us-east-1`
* Add the function's version ARN to the outputs of the stack
* Create (and use) a CloudFormation template bucket in `us-east-1`
* Remove obsolete (unsupported) properties
  * Environment
  * VPC
  * Lambda Invoke Permissions
* Update `RELEASES.md` and prepare for `v0.6.16`