### PR TITLE
feature: Autoscaling wit custom CW metric

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,41 @@
 * `p` release: Bugfixes, introduction of new features that can normally
   be used without any interruption or rebuild of resources.
 
+## `0.6.21` (20211128): ECS Autoscaling based on Custom CW Metric
+
+```yaml
+applicationconfig:
+  - name: "myservice"
+    ...
+    ecs:
+      ...
+      autoscaling:
+        - name: MyMetric
+          type: custom
+          scale_in_cooldown: 60
+          scale_out_cooldown: 60
+          target_value: 75
+          custom_metric:
+            dimensions:
+              - dim1
+              - dim2
+            metric_name: MyMetric
+            namespace: MyNameSpace
+            statistic: Sum
+```
+
+## `0.6.20` (20211116)
+
+Fix condition in logic to skip deploy user creation
+
+## `0.6.19` (20211026)
+
+Fix autoscaling mincapacity
+
+## `0.6.18` (20211008)
+
+Allow to skip deploy user creation based on a cloudfront or a global property.
+
 ## `0.6.17` (20210813)
 
 ### EFS: Create a SSM parameter for each S3 to EFS deploy bucket

--- a/templates/ECS.yml
+++ b/templates/ECS.yml
@@ -577,9 +577,21 @@ Resources:
         TargetValue: {{ as.target_value | default("75.0") }}
         ScaleInCooldown: {{ as.scale_in_cooldown | default("60") }}
         ScaleOutCooldown: {{ as.scale_out_cooldown | default("60") }}
+{%         if as.type | default('predefined') == 'predefined' %}
         PredefinedMetricSpecification:
           PredefinedMetricType: {{ as.predefined_metric_type }}
-
+{%         else %}
+        CustomizedMetricSpecification:
+{%           if as.custom_metric.dimensions is defined %}
+          Dimensions: {{ as.custom_metric.dimensions }}
+{%           endif %}
+          MetricName: {{ as.custom_metric.metric_name }}
+          Namespace: {{ as.custom_metric.namespace }}
+          Statistic: {{ as.custom_metric.statistic | default('Average') }}
+{%           if as.custom_metric.unit is defined %}
+          Unit: {{ as.custom_metric.unit }}
+{%           endif %}
+{%         endif %}
 {%       endfor %}
 {%     endif %}
 {%   endif %}

--- a/templates/ECS2.yml
+++ b/templates/ECS2.yml
@@ -592,9 +592,21 @@ Resources:
         TargetValue: {{ as.target_value | default("75.0") }}
         ScaleInCooldown: {{ as.scale_in_cooldown | default("60") }}
         ScaleOutCooldown: {{ as.scale_out_cooldown | default("60") }}
+{%         if as.type | default('predefined') == 'predefined' %}
         PredefinedMetricSpecification:
           PredefinedMetricType: {{ as.predefined_metric_type }}
-
+{%         else %}
+        CustomizedMetricSpecification:
+{%           if as.custom_metric.dimensions is defined %}
+          Dimensions: {{ as.custom_metric.dimensions }}
+{%           endif %}
+          MetricName: {{ as.custom_metric.metric_name }}
+          Namespace: {{ as.custom_metric.namespace }}
+          Statistic: {{ as.custom_metric.statistic | default('Average') }}
+{%           if as.custom_metric.unit is defined %}
+          Unit: {{ as.custom_metric.unit }}
+{%           endif %}
+{%         endif %}
 {%       endfor %}
 {%     endif %}
 {%   endif %}


### PR DESCRIPTION
## `0.6.21` (20211128): ECS Autoscaling based on Custom CW Metric

```yaml
applicationconfig:
  - name: "myservice"
    ...
    ecs:
      ...
      autoscaling:
        - name: MyMetric
          type: custom
          scale_in_cooldown: 60
          scale_out_cooldown: 60
          target_value: 75
          custom_metric:
            dimensions:
              - dim1
              - dim2
            metric_name: MyMetric
            namespace: MyNameSpace
            statistic: Sum
```
