### PR TITLE
feature: ECR policy support for cross-account Lambda pulls

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,26 @@
 * `p` release: Bugfixes, introduction of new features that can normally
   be used without any interruption or rebuild of resources.
 
+## `0.6.22` (20211201): ECR policy support for cross-account Lambda pulls
+
+The `cross_account_access.lambda` property in the ECR repo definition will add a statement
+to the ECR policy that allows all Lambda's in the specified AWS accounts to pull the
+ECR image. Also see [this AWS blog post](https://aws.amazon.com/blogs/compute/introducing-cross-account-amazon-ecr-access-for-aws-lambda/).
+
+```yaml
+ecr:
+  - name: "repoName"
+    cfn_name: RepoName
+    cross_account_access:
+      push:
+        - 000000000000
+      pull:
+        - 111111111111
+        - 222222222222
+      lambda:
+        - 333333333333
+```
+
 ## `0.6.21` (20211128): ECS Autoscaling based on Custom CW Metric
 
 ```yaml

--- a/templates/ECR.yml
+++ b/templates/ECR.yml
@@ -13,7 +13,7 @@ Resources:
       ImageScanningConfiguration:
         ScanOnPush: true
 {%   endif %}
-{%   if repo.cross_account_access is defined and repo.cross_account_access.pull is defined %}
+{%   if repo.cross_account_access is defined and ( repo.cross_account_access.pull is defined or repo.cross_account_access.push is defined or repo.cross_account_access.lambda is defined) %}
       RepositoryPolicyText:
         Version: "2012-10-17"
         Statement:
@@ -31,6 +31,25 @@ Resources:
               - "ecr:BatchGetImage"
               - "ecr:BatchCheckLayerAvailability"
               - "ecr:GetAuthorizationToken"
+{%     endif %}
+{%     if repo.cross_account_access.lambda is defined %}
+          -
+            Sid: AllowPullForCrossAccountLambda
+            Effect: Allow
+            Principal:
+              Service:
+                - "lambda.amazonaws.com"
+            Action:
+              - "ecr:GetDownloadUrlForLayer"
+              - "ecr:BatchGetImage"
+              - "ecr:BatchCheckLayerAvailability"
+              - "ecr:GetAuthorizationToken"
+            Condition:
+              StringLike:
+                aws:sourceArn:
+{%       for account_id in repo.cross_account_access.lambda %}
+                  - arn:aws:lambda:eu-central-1:{{ account_id }}:function:*
+{%       endfor %}
 {%     endif %}
 {%     if repo.cross_account_access.push is defined %}
           -


### PR DESCRIPTION
The `cross_account_access.lambda` property in the ECR repo definition will add a statement
to the ECR policy that allows all Lambda's in the specified AWS accounts to pull the
ECR image. Also see [this AWS blog post](https://aws.amazon.com/blogs/compute/introducing-cross-account-amazon-ecr-access-for-aws-lambda/).

```yaml
ecr:
  - name: "repoName"
    cfn_name: RepoName
    cross_account_access:
      push:
        - 000000000000
      pull:
        - 111111111111
        - 222222222222
      lambda:
        - 333333333333
```
