### PR TITLE
feature: allow to change ecs task runtime platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,6 @@ follow these steps:
 Following _modules_ have their own documentation file:
 
 * [Elastic Container Registry](docs/ECR.md)
-* [Elastic Container Registry (Public)](docs/ECRPublic.md)
 * [Elastic Container Service](docs/ECS.md)
 * [The mamagement ECS Fargate cluster](docs/ECSMgmt.md)
 * [KMS](docs/KMS.md)
@@ -1220,6 +1219,14 @@ looks for memory, it will require the extra memory allocated above the
 `application[n].ecs.memory_reservation` value, to be freed.
 
 This property is _stronger_ than `application[n].ecs.memory`.
+
+##### `application[n].ecs.cpuarchitecture`
+
+One of `x84_64` (default) or `ARM64`.
+
+##### `application[n].ecs.operatingsystemfamily`
+
+Will mostly be `LINUX`, See AWS documentation for other values. 
 
 ##### `application[n].ecs.cpu`
 

--- a/templates/ECS.yml
+++ b/templates/ECS.yml
@@ -333,6 +333,9 @@ Resources:
       Family: "task-{{ project }}-{{ app.name }}"
 {%     if app.launchtype | default('EC2') == 'FARGATE' %}
       Cpu: "{{ app.ecs.cpu }}"
+      RuntimePlatform:
+        CpuArchitecture: "{{ app.ecs.cpuarchitecture | default('X86_64') }}"
+        OperatingSystemFamily: "{{ app.ecs.operatingsystemfamily | default('LINUX') }}"
       Memory: "{{ app.ecs.memory }}"
       NetworkMode: awsvpc
       RequiresCompatibilities:

--- a/templates/ECS2.yml
+++ b/templates/ECS2.yml
@@ -345,6 +345,9 @@ Resources:
       Family: "task-{{ project }}-{{ app.name }}"
 {%     if app.launchtype | default('EC2') == 'FARGATE' %}
       Cpu: "{{ app.ecs.cpu }}"
+      RuntimePlatform:
+        CpuArchitecture: "{{ app.ecs.cpuarchitecture | default('X86_64') }}"
+        OperatingSystemFamily: "{{ app.ecs.operatingsystemfamily | default('LINUX') }}"
       Memory: "{{ app.ecs.memory }}"
       NetworkMode: awsvpc
       RequiresCompatibilities:


### PR DESCRIPTION
Adding the property `cpuarchitecture` and/or `operatingsystemfamily` will override the defaults of `X84_64` and/or `LINUX`