### PR TITLE
feature: allow to change ecs task runtime platform: move properties o…

### DIFF
--- a/templates/ECS.yml
+++ b/templates/ECS.yml
@@ -331,11 +331,11 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family: "task-{{ project }}-{{ app.name }}"
-{%     if app.launchtype | default('EC2') == 'FARGATE' %}
-      Cpu: "{{ app.ecs.cpu }}"
       RuntimePlatform:
         CpuArchitecture: "{{ app.ecs.cpuarchitecture | default('X86_64') }}"
         OperatingSystemFamily: "{{ app.ecs.operatingsystemfamily | default('LINUX') }}"
+{%     if app.launchtype | default('EC2') == 'FARGATE' %}
+      Cpu: "{{ app.ecs.cpu }}"
       Memory: "{{ app.ecs.memory }}"
       NetworkMode: awsvpc
       RequiresCompatibilities:

--- a/templates/ECS2.yml
+++ b/templates/ECS2.yml
@@ -343,11 +343,11 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family: "task-{{ project }}-{{ app.name }}"
-{%     if app.launchtype | default('EC2') == 'FARGATE' %}
-      Cpu: "{{ app.ecs.cpu }}"
       RuntimePlatform:
         CpuArchitecture: "{{ app.ecs.cpuarchitecture | default('X86_64') }}"
         OperatingSystemFamily: "{{ app.ecs.operatingsystemfamily | default('LINUX') }}"
+{%     if app.launchtype | default('EC2') == 'FARGATE' %}
+      Cpu: "{{ app.ecs.cpu }}"
       Memory: "{{ app.ecs.memory }}"
       NetworkMode: awsvpc
       RequiresCompatibilities:


### PR DESCRIPTION
…utside condition

Adding the property `cpuarchitecture` and/or `operatingsystemfamily` will override the defaults of `X84_64` and/or `LINUX`