### PR TITLE
Stop outputting AWS user credentials as CloudFormation outputs, but c…

### DIFF
--- a/templates/CloudFront.yml
+++ b/templates/CloudFront.yml
@@ -236,8 +236,11 @@ Resources:
             Effect: Allow
             Principal: "*"
             Action: s3:GetObject
+{%         if origin.domain is defined and origin.domain.type == 's3' %}
+            Resource: arn:aws:s3:::{{ origin.domain.name }}/*
+{%         else %}
             Resource: arn:aws:s3:::{{ origin.origin_name }}/*
-
+{%         endif %}
 {%       endif %}
 {%     endif %}
 {%   endfor %}


### PR DESCRIPTION
…reate parameter store entries instead and output the parameter names.

Fix error in resource name in BucketPolicy