### PR TITLE
Stop outputting AWS user credentials as CloudFormation outputs, but c…

### DIFF
--- a/templates/CloudFront.yml
+++ b/templates/CloudFront.yml
@@ -106,13 +106,13 @@ Resources:
   ParameterStoreAccessKeyDeploy{{ cfn_project }}:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: "/lemonade/aws-cfn-gen/cloudfront/deploy-{{ project }}/accesskey"
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/cloudfront/deploy-{{ project }}/accesskey"
       Type: String
       Value: !Ref DeployAccessKey
   ParameterStoreSecretKeyDeploy{{ cfn_project }}:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: "/lemonade/aws-cfn-gen/cloudfront/deploy-{{ project }}/secretkey"
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/cloudfront/deploy-{{ project }}/secretkey"
       Type: String
       Value: !GetAtt DeployAccessKey.SecretAccessKey
 

--- a/templates/ECR.yml
+++ b/templates/ECR.yml
@@ -189,15 +189,42 @@ Resources:
       Serial: {{ iam_accesskey_serial }}
 {%       endif %}
 
+  ParameterStoreAccessKeyECRPush:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/ecr/ECRPush/accesskey"
+      Type: String
+      Value: !Ref KeyECRPush
+
+  ParameterStoreSecretKeyECRPush:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/ecr/ECRPush/secretkey"
+      Type: String
+      Value: !GetAtt KeyECRPush.SecretAccessKey
+
+  ParameterStoreAccessKeyECRPull:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/ecr/ECRPull/accesskey"
+      Type: String
+      Value: !Ref KeyECRPull
+
+  ParameterStoreSecretKeyECRPull:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/ecr/ECRPull/secretkey"
+      Type: String
+      Value: !GetAtt KeyECRPull.SecretAccessKey
+
+
 Outputs:
-  AccessKeyECRPush:
-    Value:
-      !Ref KeyECRPush
-  SecretKeyECRPush:
-    Value: !GetAtt KeyECRPush.SecretAccessKey
-  AccessKeyECRPull:
-    Value:
-      !Ref KeyECRPull
-  SecretKeyECRPull:
-    Value: !GetAtt KeyECRPull.SecretAccessKey
+  AccessKeyParameterStoreNameECRPush:
+    Value: !Ref ParameterStoreAccessKeyECRPush
+  SecretKeyParameterStoreNameECRPush:
+    Value: !Ref ParameterStoreSecretKeyECRPush
+  AccessKeyParameterStoreNameECRPull:
+    Value: !Ref ParameterStoreAccessKeyECRPull
+  SecretKeyParameterStoreNameECRPull:
+    Value: !Ref ParameterStoreSecretKeyECRPull
 {% endif %}

--- a/templates/ECSMgmt.yml
+++ b/templates/ECSMgmt.yml
@@ -272,13 +272,13 @@ Resources:
   ParameterStoreAccessKeyDeleteAndCreateStacksUser:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: "/lemonade/aws-cfn-gen/ecsmgmt/DeleteAndCreateTaggedCloudformationStacksUser/accesskey"
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/ecsmgmt/DeleteAndCreateTaggedCloudformationStacksUser/accesskey"
       Type: String
       Value: !Ref KeyDeleteAndCreateTaggedCloudformationStacksUser
   ParameterStoreSecretKeyDeleteAndCreateStacksUser:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: "/lemonade/aws-cfn-gen/ecsmgmt/DeleteAndCreateTaggedCloudformationStacksUser/secretkey"
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/ecsmgmt/DeleteAndCreateTaggedCloudformationStacksUser/secretkey"
       Type: String
       Value: !GetAtt KeyDeleteAndCreateTaggedCloudformationStacksUser.SecretAccessKey
 
@@ -320,14 +320,14 @@ Resources:
   ParameterStoreAccessKeyAwsAssUser:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: "/lemonade/aws-cfn-gen/ecsmgmt/AwsAssUser/accesskey"
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/ecsmgmt/AwsAssUser/accesskey"
       Type: String
       Value: !Ref KeyAwsAssUser
 
   ParameterStoreSecretKeyAwsAssUser:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: "/lemonade/aws-cfn-gen/ecsmgmt/AwsAssUser/secretkey"
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/ecsmgmt/AwsAssUser/secretkey"
       Type: String
       Value: !GetAtt KeyAwsAssUser.SecretAccessKey
 
@@ -407,14 +407,14 @@ Resources:
   ParameterStoreAccessKey{{ fargate_task.cfn_name }}:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: "/lemonade/aws-cfn-gen/ecsmgmt/IAMUser{{ fargate_task.cfn_name }}/accesskey"
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/ecsmgmt/IAMUser{{ fargate_task.cfn_name }}/accesskey"
       Type: String
       Value: !Ref IAMAccessKey{{ fargate_task.cfn_name }}
 
   ParameterStoreSecretKey{{ fargate_task.cfn_name }}:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: "/lemonade/aws-cfn-gen/ecsmgmt/IAMUser{{ fargate_task.cfn_name }}/secretkey"
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/ecsmgmt/IAMUser{{ fargate_task.cfn_name }}/secretkey"
       Type: String
       Value: !GetAtt IAMAccessKey{{ fargate_task.cfn_name }}.SecretAccessKey
 

--- a/templates/IAM.yml
+++ b/templates/IAM.yml
@@ -84,13 +84,13 @@ Resources:
   ParameterStoreAccessKey{{ iam_user.cfn_name | default('A_BUG') }}:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: "/lemonade/aws-cfn-gen/iam/{{ iam_user.cfn_name | default('A_BUG') }}/accesskey"
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/iam/{{ iam_user.cfn_name | default('A_BUG') }}/accesskey"
       Type: String
       Value: !Ref Key{{ iam_user.cfn_name | default('A_BUG') }}
   ParameterStoreSecretKey{{ iam_user.cfn_name | default('A_BUG') }}:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: "/lemonade/aws-cfn-gen/iam/{{ iam_user.cfn_name | default('A_BUG') }}/secretkey"
+      Name: "/{{ organization.cfn_name }}/aws-cfn-gen/iam/{{ iam_user.cfn_name | default('A_BUG') }}/secretkey"
       Type: String
       Value: !GetAtt Key{{ iam_user.cfn_name | default('A_BUG') }}.SecretAccessKey
 {%     endif %}


### PR DESCRIPTION
…reate parameter store entries instead and output the parameter names. (ECR)

Also use variable in for tenant prefix in parameter store names for IAM, CloudFront and ECSMgmt