### PR TITLE
Security improvement: Add aws:SourceAccount condition to IAM roles to mitigate "Confused Deputy Attack"

### DIFF
--- a/templates/BastionHost.yml
+++ b/templates/BastionHost.yml
@@ -26,6 +26,9 @@ Resources:
             Principal:
               Service: [ec2.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/AmazonSSMFullAccess"

--- a/templates/CW.yml
+++ b/templates/CW.yml
@@ -39,7 +39,12 @@ Resources:
             { "Sid": "",
               "Effect": "Allow",
               "Principal": { "Service": "lambda.amazonaws.com" },
-              "Action": "sts:AssumeRole"
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": "{{ target_account.account_id }}"
+                }
+              }
             }
           ]
         }
@@ -151,7 +156,12 @@ Resources:
             { "Sid": "",
               "Effect": "Allow",
               "Principal": { "Service": "lambda.amazonaws.com" },
-              "Action": "sts:AssumeRole"
+              "Action": "sts:AssumeRole",
+              "Condition": {
+                "StringEquals": {
+                  "aws:SourceAccount": "{{ target_account.account_id }}"
+                }
+              }
             }
           ]
         }

--- a/templates/ECS.yml
+++ b/templates/ECS.yml
@@ -34,6 +34,9 @@ Resources:
             Principal:
               Service: [ecs.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       Policies:
         - PolicyName: ecs-service
@@ -54,6 +57,9 @@ Resources:
             Principal:
               Service: [ec2.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
@@ -79,6 +85,9 @@ Resources:
           Principal:
             Service: [application-autoscaling.amazonaws.com]
           Action: ['sts:AssumeRole']
+          Condition:
+            StringEquals:
+              aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       Policies:
       - PolicyName: service-autoscaling

--- a/templates/ECS2.yml
+++ b/templates/ECS2.yml
@@ -101,6 +101,9 @@ Resources:
             Principal:
               Service: [ecs.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       Policies:
         - PolicyName: ecs-service
@@ -121,6 +124,9 @@ Resources:
             Principal:
               Service: [ec2.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
@@ -146,6 +152,9 @@ Resources:
             Principal:
               Service: [application-autoscaling.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       Policies:
         - PolicyName: service-autoscaling

--- a/templates/ECSMgmt.yml
+++ b/templates/ECSMgmt.yml
@@ -19,6 +19,9 @@ Resources:
             Principal:
               Service: [ecs-tasks.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       Policies:
         - PolicyName: awslogs
@@ -43,6 +46,9 @@ Resources:
             Principal:
               Service: [events.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceEventsRole
@@ -56,6 +62,9 @@ Resources:
             Principal:
               Service: [ecs-tasks.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/CloudWatchFullAccess
@@ -106,6 +115,9 @@ Resources:
             Principal:
               Service: [ecs-tasks.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AdministratorAccess
@@ -118,6 +130,9 @@ Resources:
             Principal:
               Service: [ecs-tasks.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AdministratorAccess
@@ -428,6 +443,9 @@ Resources:
             Principal:
               Service: [ecs-tasks.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       ManagedPolicyArns:
 {%   for task_role_policy in fargate_task.task_role_policies %}

--- a/templates/ECSMgmt_IxorTalk.yml
+++ b/templates/ECSMgmt_IxorTalk.yml
@@ -20,6 +20,9 @@ Resources:
             Principal:
               Service: [ecs-tasks.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       Policies:
         - PolicyName: awslogs
@@ -38,6 +41,9 @@ Resources:
             Principal:
               Service: [ecs-tasks.amazonaws.com]
             Action: ['sts:AssumeRole']
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: /
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AdministratorAccess

--- a/templates/EFS.yml
+++ b/templates/EFS.yml
@@ -188,7 +188,7 @@ Resources:
     Properties:
       RoleName: LambdaEfsRole{{ filesystem.cfn_name }}
       AssumeRolePolicyDocument:
-        { "Version": "2012-10-17", "Statement": [ { "Sid": "", "Effect": "Allow", "Principal": { "Service": "lambda.amazonaws.com" }, "Action": "sts:AssumeRole" } ] }
+        { "Version": "2012-10-17", "Statement": [ { "Sid": "", "Effect": "Allow", "Principal": { "Service": "lambda.amazonaws.com" }, "Action": "sts:AssumeRole", "Condition": { "StringEquals": { "aws:SourceAccount": "{{ target_account.account_id }}" } } } ] }
       ManagedPolicyArns:
         - !Sub 'arn:aws:iam::${AWS::AccountId}:policy/LambdaEfsPolicy{{ filesystem.cfn_name }}'
 

--- a/templates/ElasticBeanstalkIAM.yml
+++ b/templates/ElasticBeanstalkIAM.yml
@@ -18,6 +18,9 @@ Resources:
                 - "elasticbeanstalk.amazonaws.com"
             Action:
               - "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: "/"
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/AmazonS3FullAccess"
@@ -37,6 +40,9 @@ Resources:
                 - "ec2.amazonaws.com"
             Action:
               - "sts:AssumeRole"
+            Condition:
+              StringEquals:
+                aws:SourceAccount: "{{ target_account.account_id }}"
       Path: "/"
       ManagedPolicyArns:
         - "arn:aws:iam::aws:policy/AmazonS3FullAccess"

--- a/templates/IAM.yml
+++ b/templates/IAM.yml
@@ -9,7 +9,7 @@ Resources:
     Properties:
       RoleName: ECSExecutionRoleAwsCfnGen
       AssumeRolePolicyDocument:
-        {"Version": "2012-10-17", "Statement": [{"Sid": "", "Effect": "Allow", "Principal": {"Service": "ecs-tasks.amazonaws.com"}, "Action": "sts:AssumeRole"}]}
+        {"Version": "2012-10-17", "Statement": [{"Sid": "", "Effect": "Allow", "Principal": {"Service": "ecs-tasks.amazonaws.com"}, "Action": "sts:AssumeRole", "Condition": { "StringEquals": { "aws:SourceAccount": "{{ target_account.account_id }}" } } }]}
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
 

--- a/templates/Route53Delegation.yml
+++ b/templates/Route53Delegation.yml
@@ -26,9 +26,9 @@ Resources:
           - Effect: Allow
             Principal:
               Service:
-              - lambda.amazonaws.com
+                - lambda.amazonaws.com
             Action:
-            - sts:AssumeRole
+              - sts:AssumeRole
       Path: "/"
       ManagedPolicyArns: 
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole


### PR DESCRIPTION
Security improvement: Add aws:SourceAccount condition to IAM roles to mitigate "Confused Deputy Attack"

https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html#cross-service-confused-deputy-prevention