### PR TITLE
Route53Delegation: Use customer managed KMS Key instead of AWS manage…

### DIFF
--- a/templates/Route53Delegation.yml
+++ b/templates/Route53Delegation.yml
@@ -90,7 +90,7 @@ Resources:
             !GetAtt CreateRoute53CNAME.Arn
           Protocol: lambda
       TopicName: "RequestRoute53CNAME{{ item.hostedzone.id }}"
-      KmsMasterKeyId: !Ref RequestRoute53CNAMEKmsKey.KeyId
+      KmsMasterKeyId: !GetAtt RequestRoute53CNAMEKmsKey.KeyId
 
 
   RequestRoute53CNAMEPolicy:


### PR DESCRIPTION
…d KMS Key to encrypt and decrypt SNS topic messages -- Use GetAtt rather than Ref to retrieve KeyId