### PR TITLE
Route53Delegation: Use customer managed KMS Key instead of AWS manage…

### DIFF
--- a/templates/Route53Delegation.yml
+++ b/templates/Route53Delegation.yml
@@ -69,6 +69,24 @@ Resources:
         Version: 2012-10-17
         Id: key-default-1
         Statement:
+          - Sid: Allow administration of the key
+            Effect: Allow
+            Principal:
+              AWS: "arn:aws:iam::{{ target_account.account_id }}:root"
+            Action:
+              - 'kms:Create*'
+              - 'kms:Describe*'
+              - 'kms:Enable*'
+              - 'kms:List*'
+              - 'kms:Put*'
+              - 'kms:Update*'
+              - 'kms:Revoke*'
+              - 'kms:Disable*'
+              - 'kms:Get*'
+              - 'kms:Delete*'
+              - 'kms:ScheduleKeyDeletion'
+              - 'kms:CancelKeyDeletion'
+            Resource: '*'
           - Sid: Allow use of the key
             Effect: Allow
             Principal:


### PR DESCRIPTION
…d KMS Key to encrypt and decrypt SNS topic messages -- Make sure the Key has a principal to allow management of the key.